### PR TITLE
Attempt to fix TypeScript PageProps constraint error

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,15 @@
 import GistList from '@/components/GistList';
 import { loadGists } from '@/lib/data';
 
-export default async function HomePage() {
+interface HomePageProps {
+  searchParams?: { [key: string]: string | string[] | undefined };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default async function HomePage({ searchParams: _searchParams }: HomePageProps) {
+  // searchParams 在当前逻辑中未使用，但类型已定义以保持一致性
+  // console.log(_searchParams);
+
   // 1. 加载所有的 gists
   const gists = await loadGists();
   


### PR DESCRIPTION
- Updated type definitions for page components in `src/app/page.tsx` and `src/app/gist/[gist_id]/page.tsx`.
- Added ESLint disable comments for unused variables.

Note: A persistent TypeScript error related to PageProps constraints and a Promise comparison in `src/app/gist/[gist_id]/page.tsx` remains. This may indicate a deeper issue with Next.js 15/React 19 type compatibility.